### PR TITLE
fix for CollectionMap if array key is numeric

### DIFF
--- a/src/Type/CollectionMap.php
+++ b/src/Type/CollectionMap.php
@@ -32,7 +32,7 @@ class CollectionMap extends Base{
 	public function getBinary(){
 		$data = pack('N', count($this->_value));
 		foreach($this->_value as $key => $value) {
-			$keyPacked = Base::getTypeObject($this->_keyType, (string) $key)->getBinary();
+			$keyPacked = Base::getTypeObject($this->_keyType, $key)->getBinary();
 			$data .= pack('N', strlen($keyPacked)) . $keyPacked;
 			$valuePacked = Base::getTypeObject($this->_valueType, $value)->getBinary();
 			$data .= pack('N', strlen($valuePacked)) . $valuePacked;

--- a/src/Type/Varchar.php
+++ b/src/Type/Varchar.php
@@ -4,12 +4,10 @@ namespace Cassandra\Type;
 class Varchar extends Base{
 	
 	public function __construct($value){
-		if (!is_string($value)) throw new Exception('Incoming value must be of type string.');
-	
-		$this->_value = $value;
+		$this->_value = (string)$value;
 	}
 	
 	public function getBinary(){
-		return (string)$this->_value;
+		return $this->_value;
 	}
 }


### PR DESCRIPTION
CollectionMap assumed that the array key is always a string. Let's create following table:

```
CREATE TABLE IF NOT EXISTS test_table (
    id_column int primary key,
    map_column map<text, int>
);
```

The query "UPDATE test SET map_column = ? WHERE id_column = ?" with the map_column value "new CollectionMap(['123' => 123], Base::TEXT, Base::INT)" fails because CollectionMap.php passes the int 123 to Base::getTypeObject which passes it to the Varchar class. The Varchar class throws following exception because is_string($value) is false:

PHP Fatal error:  Method Cassandra\Request\Query::__toString() must not throw an exception in /var/www/cassandra/vendor/duoshuo/php-cassandra/src/Connection.php on line 0

I typecasted the array key to string to catch this case.
