### PR TITLE
Fix issue when reading UDTs with NULL column values

### DIFF
--- a/src/Response/StreamReader.php
+++ b/src/Response/StreamReader.php
@@ -236,7 +236,7 @@ trait StreamReader {
 		$length = unpack('N', substr($this->data, $this->offset, 4))[1];
 		$this->offset += 4;
 
-		if ($length === 0xffffffff)
+		if ($length === 0xffffffff || $length === -1)
 			return null;
 
 		// do not use $this->read() for performance


### PR DESCRIPTION
I have a UDT with null columns. When public function readBytesAndConvertToType($type){...} runs, a length of -1 is returned. 

However, the code...
if ($length === 0xffffffff)
	return null;

... does not trigger. I take it the hex '0xffffffff' is supposed to be '-1' on a 32-bit system. Does using a 64-bit system make any difference? Adding '-1' to the comparison fixes the problem.