### PR TITLE
Add insert support for SETs of UDTs

### DIFF
--- a/src/Type/Base.php
+++ b/src/Type/Base.php
@@ -117,6 +117,9 @@ abstract class Base{
 			case self::UUID:
 				return new Uuid($value);
 	
+			case self::UDT:
+				return $value instanceof UDT ? $value : new UDT($value);
+				
 			default:
 				if (is_array($dataType)){
 					switch($dataType['type']){


### PR DESCRIPTION
Fixes problem when creating a request that has a value type of:

```
set<UDT>
```

This problem stems from the getBinary() function in CollectionList when a Request::valuesBinary is being packed.

Fixes #17 