### PR TITLE
Add ability to have a collection of UDT types

### DIFF
--- a/src/Type/Base.php
+++ b/src/Type/Base.php
@@ -116,6 +116,10 @@ abstract class Base{
 				return new Timeuuid($value);
 			case self::UUID:
 				return new Uuid($value);
+				
+			case self::UDT:
+				if($value instanceof UDT)
+					return $value;
 
 			default:
 				if (is_array($dataType)){


### PR DESCRIPTION
At the moment, declaring a CollectionList with a specified $_valueType of Base::UDT causes issues.

This is because when packing the List, line 29 is called:
```
$itemPacked = Base::getTypeObject($this->_valueType, $value)->getBinary();
```

Because _valueType is not an array (rather, Int 48), and $value is already a UDT instance -- Base::getTypeObject($this->_valueType, $value) needs to return $value (otherwise a Unknown Type. error is triggered).

Not sure if this logic should be added in Base.php or CollectionList.php. But this fix works for me for now.