### PR TITLE
Use stream to enable SSL

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -88,7 +88,7 @@ class Connection {
 		if ($this->connection === null)
 			return true;
 
-		return stream_socket_shutdown($this->connection);
+		return fclose($this->connection);
 	}
 	
 	/**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -87,8 +87,8 @@ class Connection {
 	public function disconnect() {
 		if ($this->connection === null)
 			return true;
-		
-		return socket_shutdown($this->connection);
+
+		return stream_socket_shutdown($this->connection);
 	}
 	
 	/**
@@ -108,10 +108,10 @@ class Connection {
 		$remainder = $length;
 
 		while($remainder > 0) {
-			$readData = socket_read($this->connection, $remainder);
+			$readData = fread($this->connection,$remainder);
 
-			if ($readData === false)
-				throw new Connection\Exception(socket_strerror(socket_last_error($this->connection)));
+			if ($readData === false || stream_get_meta_data($this->connection)['timed_out'])
+				throw new Connection\Exception(socket_strerror(socket_last_error()));
 
 			$data .= $readData;
 			$remainder -= strlen($readData);
@@ -233,8 +233,8 @@ class Connection {
 	public function syncRequest(Request\Request $request) {
 		if ($this->connection === null)
 			$this->connect();
-	
-		socket_write($this->connection, $request);
+
+		fwrite($this->connection,$request);
 		$response = $this->getResponse();
 		
 		if ($response instanceof Response\Error)
@@ -254,7 +254,7 @@ class Connection {
 		
 		$streamId = $this->_getNewStreamId();
 		$request->setStream($streamId);
-		socket_write($this->connection, $request);
+		fwrite($this->connection,$request);
 		
 		return $this->_statements[$streamId] = new Statement($this, $streamId);
 	}

--- a/src/Connection/Node.php
+++ b/src/Connection/Node.php
@@ -50,8 +50,7 @@ class Node {
 		if (!$this->socket)
 			throw new Exception("Unable to connect to Cassandra node: {$this->_options['host']}:{$this->_options['port']}");
 
-		$t = $this->_options['timeout'];
-		stream_set_timeout($this->socket,$this->_options['timeout']);		
+		stream_set_timeout($this->socket,$this->_options['timeout']);
 
 		return $this->socket;
 	}


### PR DESCRIPTION
I replaced socked with stream function to enable SSL/TLS usage. Configure nodes as following:
```
$nodes = [	
[
				'host'      => 'ssl://127.0.0.1',
				'username'  => 'cassandra',
				'password'  => 'cassandra',
				'timeout'    => 10 //seconds
		]
];
```
Socket options seems to be unavailable for PHP stream, so I replaced 'socket' option with a single option 'timeout' (for both read/write), default value is 30 seconds.
