### PR TITLE
Simplify code of consistency setting in requests

### DIFF
--- a/src/Request/Batch.php
+++ b/src/Request/Batch.php
@@ -39,9 +39,9 @@ class Batch extends Request{
 	 * @param string $consistency
 	 * @param array $options
 	 */
-	public function __construct($type = null, $consistency = null, $options = []) {
+	public function __construct($type = null, $consistency = Request::CONSISTENCY_QUORUM, $options = []) {
 		$this->_batchType = $type === null ? Batch::TYPE_LOGGED : $type;
-		$this->_consistency = $consistency === null ? Request::CONSISTENCY_QUORUM : $consistency;
+		$this->_consistency = $consistency;
 		$this->_options = $options;
 	}
 

--- a/src/Request/Execute.php
+++ b/src/Request/Execute.php
@@ -51,11 +51,11 @@ class Execute extends Request{
 	 * @param int $consistency
 	 * @param array $options
 	 */
-	public function __construct($queryId, array $values, $consistency = null, $options = []) {
+	public function __construct($queryId, array $values, $consistency, $options = []) {
 		$this->_queryId = $queryId;
 		$this->_values = $values;
 		 
-		$this->_consistency = $consistency === null ? Request::CONSISTENCY_QUORUM : $consistency;
+		$this->_consistency = $consistency;
 		$this->_options = $options;
 	}
 	

--- a/src/Request/Query.php
+++ b/src/Request/Query.php
@@ -55,7 +55,7 @@ class Query extends Request{
 	 * @param int $consistency
 	 * @param array $options
 	 */
-	public function __construct($cql, $values = [], $consistency, $options = []) {
+	public function __construct($cql, $values = [], $consistency = null, $options = []) {
 		$this->_cql = $cql;
 		$this->_values = $values;
 		$this->_consistency = $consistency;

--- a/src/Request/Query.php
+++ b/src/Request/Query.php
@@ -55,10 +55,10 @@ class Query extends Request{
 	 * @param int $consistency
 	 * @param array $options
 	 */
-	public function __construct($cql, $values = [], $consistency = null, $options = []) {
+	public function __construct($cql, $values = [], $consistency, $options = []) {
 		$this->_cql = $cql;
 		$this->_values = $values;
-		$this->_consistency = $consistency === null ? Request::CONSISTENCY_QUORUM : $consistency;
+		$this->_consistency = $consistency;
 		$this->_options = $options;
 	}
 	


### PR DESCRIPTION
Simplify code of requests because consistency is set in Connections (Batch simplified as well)