### PR TITLE
Add stream class

### DIFF
--- a/php-cassandra.php
+++ b/php-cassandra.php
@@ -29,6 +29,7 @@ require 'src/Protocol/Frame.php';
 
 require 'src/Connection/SocketException.php';
 require 'src/Connection/Socket.php';
+require 'src/Connection/Stream.php';
 
 require 'src/Request/Request.php';
 require 'src/Request/AuthResponse.php';

--- a/src/Connection/Stream.php
+++ b/src/Connection/Stream.php
@@ -1,0 +1,117 @@
+<?php
+namespace Cassandra\Connection;
+
+class Stream {
+
+	/**
+	 * @var resource
+	 */
+	protected $_stream;
+
+	/**
+	 * @var array
+	 */
+	protected $_options = [
+		'host'		=> null,
+		'port'		=> 9042,
+		'username'	=> null,
+		'password'	=> null,
+		'timeout'	=> 30,
+	];
+
+	/**
+	 * @param string|array $options
+	 */
+	public function __construct($options) {
+		if (is_string($options)){
+			$pos = strpos($options, ':');
+			if ($pos === false) {
+				$this->_options['host'] = $options;
+			}
+			else{
+				$this->_options['host'] = substr($options, 0, $pos);
+				$this->_options['port'] = (int) substr($options, $pos + 1);
+			}
+		}
+		else{
+			$this->_options = array_merge($this->_options, $options);
+		}
+
+		$this->_connect();
+	}
+
+	/**
+	 *
+	 * @throws SocketException
+	 * @return resource
+	 */
+	protected function _connect() {
+		if (!empty($this->_stream)) return $this->_stream;
+
+		$errorCode = 0;
+		$this->_stream = fsockopen($this->_options['host'], $this->_options['port'], $errorCode);
+
+		if ($this->_stream === false){
+			throw new Connection\Exception(socket_strerror($errorCode));
+		}
+
+		stream_set_timeout($this->_stream,$this->_options['timeout']);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getOptions() {
+		return $this->_options;
+	}
+
+	/**
+	 * @param $length
+	 * @throws SocketException
+	 * @return string
+	 */
+	public function read($length) {
+		$data = '';
+		$remainder = $length;
+
+		for(;$length > 0;$length -= strlen($readData)) {
+			$readData = fread($this->_stream,1);
+
+			if (feof($this->_stream))
+				throw new Connection\Exception('Connection reset by peer');
+
+			if (stream_get_meta_data($this->_stream)['timed_out'])
+				throw new Connection\Exception('Connection timed out');
+
+			if (strlen($readData) == 0)
+				throw new Connection\Exception("Unknown error");
+
+			$data .= $readData;
+		}
+		return $data;
+	}
+
+	/**
+	 *
+	 * @param string $binary
+	 * @throws SocketException
+	 */
+	public function write($binary){
+	   for ($written = 0; $written < strlen($binary); $written += $fwrite) {
+	        $fwrite = fwrite($this->_stream, substr($binary, $written));
+
+	        if (feof($this->_stream))
+				throw new Connection\Exception('Connection reset by peer');
+
+	        if (stream_get_meta_data($this->_stream)['timed_out'])
+				throw new Connection\Exception('Connection timed out');
+
+	        if ($fwrite == 0)
+				throw new Connection\SocketException("Uknown error");
+	    }
+	}
+
+	public function close(){
+		 fclose($this->_stream);
+	}
+}


### PR DESCRIPTION
Stream class implementation added.
To use define node as
```
$nodes = [
		[
				'host'      => 'ssl://'127.0.0.1',
				'username'  => 'cassandra',
				'password'  => 'cassandra',
				'class'    => 'Cassandra\Connection\Stream'
		]
];
```
I suggest integrate it in following way:

1. Move default common Socket/Stream options
```
'host'		=> null,
'port'		=> 9042,
'username'	=> null,
'password'	=> null,
```
from each class to Connection.
2. Also somehow move common __construct code
```
		if (is_string($options)){
			$pos = strpos($options, ':');
			if ($pos === false) {
				$this->_options['host'] = $options;
			}
			else{
				$this->_options['host'] = substr($options, 0, $pos);
				$this->_options['port'] = (int) substr($options, $pos + 1);
			}
		}
```
to Connection.
3. Discard 
```
else{
      $this->_node = new Connection\Socket($options);
}
```
in Connection::_connect and use 'class' option for each transport.
4. Detect 'ssl://' or 'tls://' in host prefix and invoke Stream class automatically, without making user to use 'class' option.


Items 1-2 is just nice from coding style POV, but 4 I think is necessary, user should be able just switch between protocols with prefix only.

P.S. Do we need separate SocketException class? I used Connection\Exception