### PR TITLE
Fix issue where collections having an empty string in last element has last value decoded as false instead of ''

### DIFF
--- a/src/Response/StreamReader.php
+++ b/src/Response/StreamReader.php
@@ -244,7 +244,7 @@ trait StreamReader {
 		$length = unpack('N', $binaryLength)[1];
 
 		// do not use $this->read() for performance
-		$data = substr($this->data, $this->offset, $length);
+		$data = ($length == 0) ? '' : substr($this->data, $this->offset, $length);
 		$this->offset += $length;
 
 		switch ($type) {


### PR DESCRIPTION
If you have a collection of type < TEXT> and the last element in this collection has a value that is '' (Empty String), the StreamReader responsible for converting the binary data to PHP value will incorrectly read the data for this last collection value.

Specifically the following:

```php
function readBytesAndConvertToType(...) {
...
$data = substr($this->data, $this->offset, $length);
...
}
```

Unfortunately substr returns FALSE when offset is equal to STRLEN(data)... and for Base::ASCII, VARCHAR and TEXT this FALSE is returned as is (but should be '')... 

Figured it is better performance wise if length = 0, to just return '' instead of false.

Don't fully know the ramifications with all other datatypes, but works well so far for me... and I use quite a variety.

