### PR TITLE
Fixed strict standarts error

### DIFF
--- a/src/Request/Batch.php
+++ b/src/Request/Batch.php
@@ -52,7 +52,7 @@ class Batch extends Request{
     public function getBody() {
         return pack('C', $this->_batchType)
             . pack('n', count($this->_queryArray)) . implode('', $this->_queryArray)
-            . self::queryParameters($this->_consistency, $this->_options);
+            . self::queryParameters($this->_consistency, [], $this->_options);
     }
 
     /**
@@ -87,14 +87,15 @@ class Batch extends Request{
         
         return $this;
     }
-    
+
     /**
      *
      * @param int $consistency
+     * @param array $values
      * @param array $options
      * @return string
      */
-    public static function queryParameters($consistency, array $options = []){
+    public static function queryParameters($consistency, array $values = [], array $options = []){
         $flags = 0;
         $optional = '';
     


### PR DESCRIPTION
When use Batch request always have a problem with "Declaration of Cassandra\Request\Batch::queryParameters() should be compatible with Cassandra\Request\Request::queryParameters($consistency, array $values = Array, array $options = Array)"
