### PR TITLE
Support SSL connection with PHP 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,16 @@ $nodes = [
 		'timeout'	=> 30, // write/recv timeout, default 30, stream transport only
 		'persistent'	=> true, // use persistent PHP connection, default false,  stream transport only  
 	],
-	[				// advanced way, using SSL
+	[				// advanced way, using SSL(TLS)
 		'class'		=> 'Cassandra\Connection\Stream', // "class" must be defined as "Cassandra\Connection\Stream" for ssl or tls
 		'host'		=> 'ssl://10.205.48.70',// or 'tls://10.205.48.70'
 		'port'		=> 9042,
 		'username'	=> 'admin',
 		'password'	=> 'pass',
+		//disable certificate verification
+		'ssl'		=> ['verify_peer'=>false,'verify_peer_name'=>false],
+		//with SSL certificate validation, no name check
+		//'ssl'		=> ['cafile' => 'cassandra.pem', 'verify_peer_name'=>false]
 	],
 ];
 

--- a/src/Connection/Stream.php
+++ b/src/Connection/Stream.php
@@ -38,9 +38,14 @@ class Stream {
 	protected function _connect() {
 		if (!empty($this->_stream)) return $this->_stream;
 
-		$this->_stream = $this->_options['persistent']
-			? pfsockopen($this->_options['host'], $this->_options['port'], $errorCode, $errorMessage, $this->_options['connectTimeout'])
-			: fsockopen($this->_options['host'], $this->_options['port'], $errorCode, $errorMessage, $this->_options['connectTimeout']);
+		$context = stream_context_create();
+		if (isset($this->_options['ssl'])){
+			foreach($this->_options['ssl'] as $optname => $optval)
+				stream_context_set_option($context, 'ssl', $optname, $optval);
+		}
+
+		$connFlag = $this->_options['persistent'] ? STREAM_CLIENT_PERSISTENT : STREAM_CLIENT_CONNECT ;
+ 		$this->_stream = stream_socket_client($this->_options['host'].':'. $this->_options['port'], $errorCode, $errorMessage, $this->_options['connectTimeout'], $connFlag, $context);
 
 		if ($this->_stream === false){
 			throw new StreamException($errorMessage, $errorCode);


### PR DESCRIPTION
PHP 5.6 verify SSL certificate by default. (http://php.net/manual/en/migration56.openssl.php)

**stream_socket_client** with **stream_context_set_option** is used to allow verification config.
